### PR TITLE
2.0.1 Handle chunked json

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,9 @@
 
 [![NPM Version](https://img.shields.io/npm/v/looshis-local-logger.svg?style=flat)](https://www.npmjs.com/package/looshis-local-logger) [![NPM Downloads](https://img.shields.io/npm/dt/looshis-local-logger.svg?style=flat)](https://www.npmjs.com/package/looshis-local-logger)
 
-Stream logs in the browser!
+View and filter logs in a browser during local development.
 
 ![browser window showing logs](https://github.com/looshi/looshis-local-logger/blob/main/examples/example.png)
-
-LLL is a command line program to view and filter terminal output in a browser.
 
 LLL has no dependencies!
 
@@ -26,14 +24,14 @@ npm i -g looshis-local-logger
 ### Examples
 
 ```sh
-# Pipe standard error in addition to standard output to lll.
+# Pipe standard error in addition to standard output to lll
 ./your-app  |& lll
 
 # Pipe only standard output to lll, ignore standard error
 ./your-app | lll
 
 # Specify a different port for lll
-/your-app |& LLL_PORT=1234 lll
+./your-app | LLL_PORT=1234 lll
  # http://localhost:1234
 
 # Run an npm script
@@ -42,3 +40,35 @@ npm run start |& lll
 # Start a ruby app
 ruby ./ruby.rb |& lll
 ```
+
+### Filtering output
+
+There is an editable javascript function at the top of the browser screen, it must be named "transform" and accepts one argument "logs" which are all of the logs received since the browser has been open. This can be edited to filter, map, and limit the output. Here are some examples:
+
+```js
+// Display only logs that contain the string "spinal tap", limit to 11
+function transform(logs) {
+  return logs.slice(-11).filter((log) => {
+    return log.includes("spinal tap");
+  });
+}
+```
+
+```js
+// Display only some nested property of JSON logs
+function transform(logs) {
+  return logs.map((log) => {
+    try {
+      return JSON.parse(log).some.nested.property;
+    } catch (e) {
+      return "could not parse";
+    }
+  });
+}
+```
+
+## About
+
+lll attempts to organize logs visually. Large logs may sometimes span multiple blocks due to size limitations of piping stdin. lll does its best to keep large JSON-stringified logs in tact. Other kinds of large logs may span multiple blocks in the browser ouptput, e.g. ruby, python, or stderr Error output, in the future this could be addressed.
+
+lll has no dependencies and uses only javascript, html, css, and the built in node Test runner.

--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ function transform(logs) {
 
 ## About
 
-lll attempts to organize logs visually. Large logs may sometimes span multiple blocks due to size limitations of piping stdin. lll does its best to keep large JSON-stringified logs in tact. Other kinds of large logs may span multiple blocks in the browser ouptput, e.g. ruby, python, or stderr Error output, in the future this could be addressed.
+lll is a command line utility that serves its stdin to a browser. lll is designed to be used for local development where a lot of logs are being generated and need to be filtered, formatted, copy/pasted, etc.
+
+lll attempts to organize logs visually. Large logs may sometimes span multiple blocks due to size limitations of piping stdin. lll does its best to keep large JSON-stringified logs in tact. Other kinds of large logs may span multiple blocks, but this may be fixed or addressed in the future.
 
 lll has no dependencies and uses only javascript, html, css, and the built in node Test runner.

--- a/examples/node-app/index.js
+++ b/examples/node-app/index.js
@@ -1,9 +1,12 @@
 function log() {
   const time = Math.ceil(Math.random() * 3);
+  console.log("{ try to break the json: parser");
+  console.log({ small_log_A: true });
+  console.log({ small_log_B: false });
   setTimeout(() => {
     time === 1 ? console.error(err) : console.log(data());
     log();
-  }, time * 500);
+  }, time * 300);
 }
 log();
 
@@ -12,6 +15,9 @@ const data = () =>
     node: "Example of a node app logging to stdout",
     time: Date.now(),
     MY_VAR: process.env.MY_VAR,
-    large_array: Array(10).fill("cats"),
+    small_array: Array(Math.ceil(Math.random() * 10)).fill("dogs"),
+    large_array: Array(Math.ceil(Math.random() * 200)).fill(
+      "cats ".repeat(Math.random() * 200)
+    ),
   });
 const err = new Error("node.js example error");

--- a/examples/node-app/index.js
+++ b/examples/node-app/index.js
@@ -1,8 +1,10 @@
 function log() {
   const time = Math.ceil(Math.random() * 3);
   console.log("{ try to break the json: parser");
-  console.log({ small_log_A: true });
-  console.log({ small_log_B: false });
+  console.log(JSON.stringify({ small_log_A: true, stringified: true }));
+  console.log({ small_log_B: false, stringified: false });
+  console.log(JSON.stringify(["a", "small", "array"]));
+  console.log(JSON.stringify(["a", "large".repeat(1000), "array"]));
   setTimeout(() => {
     time === 1 ? console.error(err) : console.log(data());
     log();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "looshis-local-logger",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "View terminal output in browser",
   "scripts": {
     "start": "node src/server.js",

--- a/src/client.html
+++ b/src/client.html
@@ -180,7 +180,7 @@
             aria-describedby="transform-instructions"
           >
             <li>function transform(logs){</li>
-            <li>&nbsp;&nbsp;return logs.filter(log => {</li>
+            <li>&nbsp;&nbsp;return logs.slice(-50).filter(log => {</li>
             <li>&nbsp;&nbsp;&nbsp;&nbsp;return true;</li>
             <li>&nbsp;&nbsp;});</li>
             <li>}</li>
@@ -229,15 +229,20 @@
         "transform-fn-status"
       );
 
+      const updateTransformFn = () => {
+        STATE.TRANSFORM_FN = new Function(
+          "all_logs",
+          filterFunctionEl.textContent + "return transform(all_logs);"
+        );
+      };
+      updateTransformFn(); //Initializes transform fn to the default set in html above
+
       let timeoutId;
       filterFunctionEl.addEventListener("keyup", () => {
         transformFnStatusEl.innerHTML = "...";
         clearTimeout(timeoutId); // debounces
         timeoutId = setTimeout(() => {
-          STATE.TRANSFORM_FN = new Function(
-            "all_logs",
-            filterFunctionEl.textContent + "return transform(all_logs);"
-          );
+          updateTransformFn();
           transformFnStatusEl.innerHTML = "&#x2713;";
           render(allLogs);
         }, 777);

--- a/src/client.html
+++ b/src/client.html
@@ -206,7 +206,7 @@
           referrerpolicy="origin"
           target="_blank"
         >
-          Looshi's Local Logger v2.0.0
+          Looshi's Local Logger v2.0.1
         </a>
       </p>
     </footer>

--- a/src/client.html
+++ b/src/client.html
@@ -92,7 +92,7 @@
 
     .filter-function-area {
       background: #1d1e22;
-      padding: 8px 24px 0 0;
+      padding: 0 24px 0 0;
       border: 1px solid #1d1e22;
     }
     .filter-function-area:focus-within {
@@ -153,6 +153,7 @@
     #transform-instructions {
       font-style: italic;
       padding-right: 0;
+      padding-left: 0;
       color: rgb(115, 115, 115);
     }
     #transform-fn-status {
@@ -167,12 +168,10 @@
     <button id="copy-button">Copy</button>
     <header>
       <div>
+        <label id="transform-instructions" for="code_editor">
+          Filter, map, limit, etc. (JS)<span id="transform-fn-status"></span>
+        </label>
         <div class="filter-function-area">
-          <p id="transform-instructions">
-            // Filter, map, limit, etc. (JS)<span
-              id="transform-fn-status"
-            ></span>
-          </p>
           <ol
             id="code-editor"
             contenteditable
@@ -197,7 +196,7 @@
         <button id="clear-btn">Clear Logs</button>
       </div>
     </header>
-    <div id="filter-count"></div>
+    <div id="filter-count">No logs yet</div>
     <main tabindex="0"></main>
     <footer>
       <p id="status"></p>

--- a/src/server.js
+++ b/src/server.js
@@ -5,7 +5,7 @@ import path from "path";
 import { fileURLToPath } from "url";
 const HERE = fileURLToPath(import.meta.url);
 const CLIENT_FILE_PATH = `${path.dirname(HERE)}/client.html`;
-const VERSION = "LLL v2.0.0";
+const VERSION = "LLL v2.0.1";
 const port = process.env.LLL_PORT || 4000;
 let client; // allows only one client running at one time
 

--- a/src/server.js
+++ b/src/server.js
@@ -51,9 +51,16 @@ function onStdIn(data) {
         line.includes(":") &&
         !line.endsWith("}") &&
         line.length > 256;
-      if (isConcating === false && isLargeJsonStart) {
+      const isLargeArrayStart =
+        line.startsWith("[") &&
+        line.includes(",") &&
+        line.length > 256 &&
+        !line.endsWith("]");
+
+      if (isConcating === false && (isLargeJsonStart || isLargeArrayStart)) {
         isConcating = true;
       }
+
       if (isConcating) {
         try {
           lastGoodJSON += line.trim();

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -67,13 +67,13 @@ test("lll with options and NO pipe", async (t) => {
   await t.test("-v", options, async (t) => {
     const cmd = "npm run start -- -v";
     const { stdout } = await execPromise(cmd);
-    assert(stdout.includes("LLL v2.0.0"));
+    assert(stdout.includes("LLL v2.0.1"));
   });
 
   await t.test("--version", options, async (t) => {
     const cmd = "npm run start -- --version";
     const { stdout } = await execPromise(cmd);
-    assert(stdout.includes("LLL v2.0.0"));
+    assert(stdout.includes("LLL v2.0.1"));
   });
 
   await t.test("unsupported option", options, async (t) => {


### PR DESCRIPTION
Allows large json objects that arrive in multiple stdin events to be sent to the html client as one event.

Allows small json objects that arrive in stdin in a batch to be sent as individual events to the html client.

Sets a default limit of 50 in the html client via array slice(-50) in the html.